### PR TITLE
LaTeX output implementation

### DIFF
--- a/macros/plot_tt.py
+++ b/macros/plot_tt.py
@@ -130,4 +130,5 @@ os.system('mkdir {}'.format(output_dir))
 for var in variables:
     plotter.draw(var, 'Number of events')
     plotter.write('{}/{}.png'.format(output_dir,var))
+    plotter.write('{}/{}.tex'.format(output_dir,var))
     print plotter.plot

--- a/tools/plotting/plotter.py
+++ b/tools/plotting/plotter.py
@@ -98,6 +98,9 @@ class Plotter(object):
    
     def write(self, fname):
         self.can.SaveAs(fname)
+        if '.tex' in fname:
+            import os
+            os.system("sed -i 's|mark=|mark=*|g' "+fname)
     
     def print_info(self, detector, xmin=None, ymin=None):
         lumitext = ''


### PR DESCRIPTION
Get a tex output for plots, still use `\includegraphics` as before but text in now TeX generated and plot is vectorial:
```TeX
\includegraphics[width=.5\linewidth]{plots_1912_tt/l1_eta.png}
```
becomes
```TeX
\includegraphics[width=.5\linewidth]{plots_1912_tt/l1_eta.tex}
```

In the file `tools/plotting/plotter.py`, a `sed` os command as been added to set the pgf marker properly as it is not done by default, so that the ouput tex file can be directly used.

@cbernet